### PR TITLE
Explicit string argument for privateKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Step 3: Next you must initialize the instance of this module with the proper Pro
 //main.js
 var layerProviderID = 'YOUR-PROVIDER ID-HERE';  // Should have the format of layer:///providers/<GUID>
 var layerKeyID = 'YOUR-KEY ID-HERE';   // Should have the format of layer:///keys/<GUID>
-var privateKey = fs.readFileSync('cloud/layer-parse-module/keys/layer-key.js');
+var privateKey = fs.readFileSync('cloud/layer-parse-module/keys/layer-key.js').toString();
 layer.initialize(layerProviderID, layerKeyID, privateKey);
 ```
         


### PR DESCRIPTION
By passing a Buffer argument, we got `init failed:TypeError: a.replace is not a function`
Update README so that Cloud code integration works as expected.